### PR TITLE
pkp/plagiarism#29 provide an extra option for DATETIME regex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,13 @@
 {
 	"require": {
-		"bsobbe/ithenticate": "dev-master#8440a85"
+		"bsobbe/ithenticate": "dev-master#8440a85",
+		"cweagans/composer-patches": "^1.7"
+	},
+	"extra": {
+		"patches": {
+			"phpxmlrpc/phpxmlrpc": {
+				"Allow other datetime possibility": "lib/phpxmlrpc-datetime.diff"
+			}
+		}
 	}
 }

--- a/lib/phpxmlrpc-datetime.diff
+++ b/lib/phpxmlrpc-datetime.diff
@@ -1,0 +1,11 @@
+--- src/Helper/XMLParser_patched.php    2022-05-24 13:15:28.159700424 -0300
++++ src/Helper/XMLParser.php	2016-01-20 19:28:09.000000000 -0400
+@@ -270,7 +270,7 @@
+                     if ($name == 'STRING') {
+                         $this->_xh['value'] = $this->_xh['ac'];
+                     } elseif ($name == 'DATETIME.ISO8601') {
+-                        if (!preg_match('/^[0-9]{8}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $this->_xh['ac'])) {
++                        if (!preg_match('/^[0-9]{8}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $this->_xh['ac']) || !preg_match('/^[0-9]{8}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $this->_xh['ac'])) {
+                             error_log('XML-RPC: ' . __METHOD__ . ': invalid value received in DATETIME: ' . $this->_xh['ac']);
+                         }
+                         $this->_xh['vt'] = Value::$xmlrpcDateTime;


### PR DESCRIPTION
hi @asmecher  this PR includes a patch in a lib/ directory that composer will apply to the PHPXMLRPC vendor library.  It adds an extra possibility for the datetime format, so both will work.  I didn't want to just switch it in case it was working correctly in other server environments.