### PR TITLE
pkp#29: Correct composer phpxmlrpc patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,10 @@
 				"Allow other datetime possibility": "lib/phpxmlrpc-datetime.diff"
 			}
 		}
+	},
+	"config": {
+		"allow-plugins": {
+			"cweagans/composer-patches": true
+		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80bb207be22274306acfdd1ed833f68e",
+    "content-hash": "f66a864bb4f2aff1802114fc85909a5d",
     "packages": [
         {
             "name": "bsobbe/ithenticate",
@@ -54,7 +54,55 @@
                 "issues": "https://github.com/bsobbe/iThenticate/issues",
                 "source": "https://github.com/bsobbe/iThenticate/tree/master"
             },
-            "time": "2021-06-04T12:29:15+00:00"
+            "time": "2021-12-12T09:19:44+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
         },
         {
             "name": "phpxmlrpc/phpxmlrpc",
@@ -122,5 +170,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/lib/phpxmlrpc-datetime.diff
+++ b/lib/phpxmlrpc-datetime.diff
@@ -5,7 +5,7 @@
                          $this->_xh['value'] = $this->_xh['ac'];
                      } elseif ($name == 'DATETIME.ISO8601') {
 -                        if (!preg_match('/^[0-9]{8}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $this->_xh['ac'])) {
-+                        if (!preg_match('/^[0-9]{8}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $this->_xh['ac']) || !preg_match('/^[0-9]{8}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $this->_xh['ac'])) {
++                        if (!preg_match('/^[0-9]{8}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $this->_xh['ac']) || !preg_match('/^[0-9\-]{10}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/', $this->_xh['ac'])) {
                              error_log('XML-RPC: ' . __METHOD__ . ': invalid value received in DATETIME: ' . $this->_xh['ac']);
                          }
                          $this->_xh['vt'] = Value::$xmlrpcDateTime;

--- a/lib/phpxmlrpc-datetime.diff
+++ b/lib/phpxmlrpc-datetime.diff
@@ -5,7 +5,7 @@
                          $this->_xh['value'] = $this->_xh['ac'];
                      } elseif ($name == 'DATETIME.ISO8601') {
 -                        if (!preg_match('/^[0-9]{8}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $this->_xh['ac'])) {
-+                        if (!preg_match('/^[0-9]{8}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $this->_xh['ac']) || !preg_match('/^[0-9\-]{10}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/', $this->_xh['ac'])) {
++                        if (!preg_match('/^[0-9]{8}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $this->_xh['ac']) && !preg_match('/^[0-9\-]{10}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/', $this->_xh['ac'])) {
                              error_log('XML-RPC: ' . __METHOD__ . ': invalid value received in DATETIME: ' . $this->_xh['ac']);
                          }
                          $this->_xh['vt'] = Value::$xmlrpcDateTime;


### PR DESCRIPTION
Corrects the datetime regular expression and ensures that `composer install` actually deploys the patch.  Resolves #29.